### PR TITLE
Fix Path update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Fix PATH
           command: |
             echo "see https://github.com/CircleCI-Public/browser-tools-orb/blob/de5fa4e28909039438189815dbb42ac308e49bc9/src/scripts/install-chromedriver.sh#L187"
-            export PATH="/usr/local/bin/chromedriver:$PATH" >> $BASH_ENV
+            echo "export PATH='/usr/local/bin/chromedriver:$PATH'" >> $BASH_ENV
       - run:
           command: |
             google-chrome --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,11 @@ jobs:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:
+          name: Fix PATH
+          command: |
+            echo "see https://github.com/CircleCI-Public/browser-tools-orb/blob/de5fa4e28909039438189815dbb42ac308e49bc9/src/scripts/install-chromedriver.sh#L187"
+            export PATH="/usr/local/bin/chromedriver:$PATH" >> $BASH_ENV
+      - run:
           command: |
             google-chrome --version
             chromedriver --version


### PR DESCRIPTION
Re: Errors finding the `chromedriver` binary is seen for subsequent steps after the `browser-tools/install-chromedriver` step.
https://app.circleci.com/pipelines/github/kelvintaywl-cci/browser-tools-142/2/workflows/8d9b616c-17af-4829-9edf-4c7c52f94a85/jobs/2

I noted that the $PATH is updated to include the Chrome Driver's binary path.
https://github.com/CircleCI-Public/browser-tools-orb/blame/de5fa4e28909039438189815dbb42ac308e49bc9/src/scripts/install-chromedriver.sh#L187

However, this is not persisted beyond the shell session of the installation step.

Hence, this PR showcases a workaround for now, to add onto the $BASH_ENV with the $PATH updates.
See fixed build:
https://app.circleci.com/pipelines/github/kelvintaywl-cci/browser-tools-142/4/workflows/342deb4d-d683-40ce-8c7c-a11c8a5fc077/jobs/5

I am not 100% sure all execution environments will have the $BASH_ENV available, so this solution may not work for all?
